### PR TITLE
Towards mathcomp-like proof script

### DIFF
--- a/robustmean.v
+++ b/robustmean.v
@@ -65,10 +65,9 @@ Proof.
       \sum_(i0 in finset (preim X (pred1 i)) :&: F)
        (X i0 * Ind (A:=U) F i0 * P i0).
     + apply congr_big => // i0.
-      rewrite in_setI.
-      move/andP => [+ H0].
-      rewrite in_preim1' => /eqP ->.
-      by rewrite /Ind H0 mulR1.
+      rewrite in_setI /Ind.
+      move/andP => [] /in_preim1 -> ->.
+      by rewrite mulR1.
     have H1:
       \sum_(i0 in finset (preim X (pred1 i)) :\: F) X i0 * Ind F i0 * P i0 = 0.
     (* This should be true because all elements of the sum are 0 *)

--- a/robustmean.v
+++ b/robustmean.v
@@ -7,28 +7,40 @@ From infotheo Require Import ssrR Reals_ext logb ssr_ext ssralg_ext bigop_ext Rb
 From infotheo Require Import proba fdist.
 Require Import Setoid Ring.
 
+Set Implicit Arguments.
+Unset Strict Implicit.
+Unset Printing Implicit Defensive.
+
 
 Local Open Scope proba_scope.
 Local Open Scope big_scope.
 Local Open Scope R_scope.
 
+(* Reset the default interpretation of "==" (which is overridden by Setoid) *)
+Local Open Scope bool_scope.
 
 Notation "X `* Y" := (fun x => X x * Y x) : proba_scope.
 
 
 Section sets_functions.
 
-Lemma set1U (X:finType) (A:{set X}) (x:X) : [set x] :&: A = if x \in A then [set x] else set0.
+Lemma set1I (X:finType) (x:X) (A:{set X}) :
+  [set x] :&: A = if x \in A then [set x] else set0.
 Proof.
-  destruct (x \in A) eqn:H0.
-  - by apply /setIidPl; rewrite sub1set.
-  - by apply /disjoint_setI0; rewrite disjoints1; rewrite H0.
+  case H0: (x \in A).
+  - by apply/setIidPl; rewrite sub1set.
+  - by apply/disjoint_setI0; rewrite disjoints1 H0.
 Qed.
 
-Lemma in_preim : forall (A:finType) (B:eqType) (a:A) (b:B) X,
+Lemma in_preim1 (A:finType) (B:eqType) (a:A) (b:B) X :
   (a \in finset (T:=A) (preim X (pred1 b))) -> X a = b.
+Proof. by rewrite in_set=> /eqP. Qed.
+
+Lemma in_preim1' (A:finType) (B:eqType) (a:A) (b:B) X :
+  (a \in finset (T:=A) (preim X (pred1 b))) = (X a == b).
 Proof.
-  move => A B i i0 X; rewrite in_set; move => /eqP-H; by [].
+  apply/idP; case H: (X a == b); first by move/eqP: H <-; rewrite inE /= eqxx.
+  by move: H=> /[swap] /in_preim1 ->; rewrite eqxx.
 Qed.
 
 Lemma leq_sumR I r (P : pred I) (E1 E2 : I -> R) :
@@ -75,7 +87,7 @@ Proof.
   destruct H.
   simpl in *.
   assert (X i0 = i).
-  apply in_preim. auto.
+  apply in_preim1. auto.
   rewrite H1.
   unfold Ind.
   destruct (i0 \in F).
@@ -1066,7 +1078,7 @@ Proof.
   lra.
   lra.
 Qed.
-
+Arguments Ind_one : clear implicits.
 
 Theorem robust_mean
   (good drop: {set U})
@@ -1634,6 +1646,7 @@ Proof.
   lra.
 Qed.
 
+End probability.
 
 Require Import List.
 Require Import Sorting.

--- a/robustmean.v
+++ b/robustmean.v
@@ -85,26 +85,16 @@ Proof.
   by rewrite -sum_parti_finType.
 Qed.
 
+Lemma sq_RV_ge0 (X : {RV P -> R}) x : 0 <= (X `^2) x.
+Proof. exact: pow2_ge_0. Qed.
+
 Lemma Ex_square_ge0
   (X: {RV P -> R}):
     0 <= `E (X `^2).
 Proof.
   unfold Ex.
-  assert (\sum_(u in U) 0 = 0).
-  apply psumR_eq0P.
-  move => a H. lra.
-  move => a H. lra.
-  rewrite <- H.
-  apply leq_sumR.
-  move => i H0.
-  unfold ambient_dist, "`^2", "`o".
-  rewrite <- (Rmult_0_r 0).
-  apply Rmult_le_compat.
-  lra. lra.
-  unfold "^".
-  rewrite Rmult_1_r.
-  apply Rle_0_sqr.
-  apply FDist.ge0.
+  apply big_ind => //; first by apply addR_ge0.
+  by move=> *; apply mulR_ge0 => //; apply sq_RV_ge0.
 Qed.
 
 Lemma Ex_square_expansion


### PR DESCRIPTION
Let us work on the mathcomp/ssreflect-like proof script in this draft PR.

In the first commit, I have made the following small changes:
- declare Implicit Arguments and related switches at the beginning of the script
- change the names of lemmas: `set1U` -> `set1I`, `in_preim` -> `in_preim1`
- compress the scripts of these lemmas
- unset the implicit argument of `Ind_one`
- Insert `End probability.` before `Module ROrder` to make the compilation succeed
- 